### PR TITLE
Rework ethbalance

### DIFF
--- a/ethbalance/errors.go
+++ b/ethbalance/errors.go
@@ -1,0 +1,58 @@
+package ethbalance
+
+import "fmt"
+
+// RequestError wraps a request with the error received
+type RequestError struct {
+	Request *BalanceRequest
+	Err     error
+}
+
+func (re RequestError) section() string {
+	return fmt.Sprintf("    %d %s %s", re.Request.Block, re.Request.Address, re.Request.Source)
+}
+
+// CollectBalancesError wraps errors returned from the RPC requests
+type CollectBalancesError struct {
+	Errors []*RequestError
+}
+
+// Error message aggregates all unique errors
+func (cbe CollectBalancesError) Error() string {
+	fullErrorMessage := renderFullErrorMessage(cbe.Errors)
+	return fmt.Sprintf("Unable to collect balances because of these errors:\n%s", fullErrorMessage)
+}
+
+// DecodeBalancesError wraps errors returned when trying to decode the responses
+type DecodeBalancesError struct {
+	Errors []*RequestError
+}
+
+// Error message aggregates all unique errors
+func (dbe DecodeBalancesError) Error() string {
+	fullErrorMessage := renderFullErrorMessage(dbe.Errors)
+	return fmt.Sprintf("Unable to collect balances because of these errors:\n%s", fullErrorMessage)
+}
+
+func renderFullErrorMessage(errors []*RequestError) string {
+	var fullErrorMessage string
+	errorMessages := make(map[string]string)
+	index := 0
+
+	for _, reqError := range errors {
+		errorMessageKey := reqError.Err.Error()
+		sectionError, ok := errorMessages[errorMessageKey]
+		if !ok {
+			sectionError = fmt.Sprintf("[%d] %s\n    Requests:\n", index, errorMessageKey)
+			index++
+		}
+		sectionError += reqError.section() + "\n"
+		errorMessages[errorMessageKey] = sectionError
+	}
+
+	for _, errorMessage := range errorMessages {
+		fullErrorMessage += errorMessage
+	}
+
+	return fullErrorMessage
+}

--- a/ethbalance/types.go
+++ b/ethbalance/types.go
@@ -1,0 +1,52 @@
+package ethbalance
+
+import (
+	"math/big"
+
+	"github.com/alethio/web3-go/ethrpc"
+)
+
+// Bookkeeper wraps the operations
+type Bookkeeper struct {
+	eth     ethrpc.ETHInterface
+	retries uint
+}
+
+// BlockNumber : wrapper type for a block numnber
+type BlockNumber = uint64
+
+// Address : wrapper type for an ETH address
+type Address = string
+
+// RawBalanceSheet : the tree-like structure representing all un-parsed balances
+type RawBalanceSheet = map[BlockNumber]map[Address]map[Source]string
+
+// IntBalanceSheet : the tree-like structure with all balances converted to big.Int
+type IntBalanceSheet = map[BlockNumber]map[Address]map[Source]*big.Int
+
+// Source : either "ETH" or a token address
+type Source string
+
+const (
+	// ETH : Ethereum source
+	ETH Source = "ETH"
+)
+
+// BalanceRequest : a unit of work
+type BalanceRequest struct {
+	Block   BlockNumber
+	Address Address
+	Source  Source
+}
+
+// RawBalanceResponse : the raw response associated with a balance request
+type RawBalanceResponse struct {
+	Request *BalanceRequest
+	Balance string
+}
+
+// IntBalanceResponse : the converted response associated with a balance request
+type IntBalanceResponse struct {
+	Request *BalanceRequest
+	Balance *big.Int
+}

--- a/ethrpc/interface.go
+++ b/ethrpc/interface.go
@@ -27,6 +27,8 @@ type ETHInterface interface {
 	GetPeerCount() (peers int64, err error)
 	GetPendingFilterChanges(id string) (t []string, err error)
 	GetPendingTransactions() ([]types.Transaction, error)
+	GetRawBalanceAtBlock(address, blockNumber string) (string, error)
+	GetRawTokenBalanceAtBlock(address, token, blockNumber string) (string, error)
 	GetTokenBalanceAtBlock(address, token, blockNumber string) (*big.Int, error)
 	GetTransactionByHash(hash string) (types.Transaction, error)
 	GetTransactionReceipt(hash string) (r types.Receipt, err error)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/alethio/ethmock v0.0.0-20190607140831-ce4476424f5c
+	github.com/davecgh/go-spew v1.1.1
 	github.com/go-test/deep v1.0.1
 	github.com/gorilla/websocket v1.4.0
 	github.com/sirupsen/logrus v1.4.2

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alethio/web3-go/ethbalance"
 	"github.com/alethio/web3-go/ethrpc"
 	"github.com/alethio/web3-go/ethrpc/provider/httprpc"
+	"github.com/davecgh/go-spew/spew"
 )
 
 type worker struct {
@@ -43,7 +44,7 @@ func main() {
 			log.Fatal(err)
 		}
 		provider, err := httprpc.NewWithLoader(ethURL, batchLoader)
-		provider.SetHTTPTimeout(5000 * time.Millisecond)
+		// provider.SetHTTPTimeout(2 * time.Millisecond)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -157,25 +158,48 @@ func main() {
 		}
 		log.Println(balance)
 	case "getBalances":
-		b := ethbalance.New(w.eth, 10)
-		accounts := map[string][]string{
-			"0xa838e871a02c6d883bf004352fc7dac8f781fed6": []string{
-				"0xBEB9eF514a379B997e0798FDcC901Ee474B6D9A1",
-				"0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
-				"0xd26114cd6EE289AccF82350c8d8487fedB8A0C07",
-				"0x8aa33a7899fcc8ea5fbe6a608a109c3893a1b8b2",
+		b := ethbalance.New(w.eth, 5)
+		requests := []*ethbalance.BalanceRequest{
+			&ethbalance.BalanceRequest{
+				Address: "0xa838e871a02c6d883bf004352fc7dac8f781fed6",
+				Source:  ethbalance.ETH,
+				Block:   7000000,
+			},
+			&ethbalance.BalanceRequest{
+				Address: "0xa838e871a02c6d883bf004352fc7dac8f781fed6",
+				Source:  "0xBEB9eF514a379B997e0798FDcC901Ee474B6D9A1",
+				Block:   7000000,
+			},
+			&ethbalance.BalanceRequest{
+				Address: "0xa838e871a02c6d883bf004352fc7dac8f781fed6",
+				Source:  "0xd26114cd6EE289AccF82350c8d8487fedB8A0C07",
+				Block:   7000000,
+			},
+			&ethbalance.BalanceRequest{
+				Address: "0xa838e871a02c6d883bf004352fc7dac8f781fed6",
+				Source:  "0x8aa33a7899fcc8ea5fbe6a608a109c3893a1b8b2",
+				Block:   7000000,
+			},
+			&ethbalance.BalanceRequest{
+				Address: "0xa838e871a02c6d883bf004352fc7dac8f781fed6",
+				Source:  "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
+				Block:   7000000,
 			},
 		}
-		balances, err := b.GetBalancesAtBlock(accounts, "latest")
+		rawBalances, err := b.GetRawBalanceSheet(requests)
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
-		for account, accountBalances := range balances {
-			for source, value := range accountBalances {
-				fmt.Printf("%s[%s]: %v\n", account, source, value)
-			}
+		fmt.Println("--------------- Raw Balances -----------------")
+		spew.Dump(rawBalances)
+		intBalances, err := b.GetIntBalanceSheet(requests)
+		if err != nil {
+			fmt.Println(err)
+			return
 		}
+		fmt.Println("--------------- big.Int Balances -----------------")
+		spew.Dump(intBalances)
 	default:
 		log.Println("Command not implemented")
 	}


### PR DESCRIPTION
> This branch was made on top of #3 so it should only be reviewed after that one is merged and this one gets rebased on master.

### Summary

The initial design of `ethbalance` was just a trial for something to be used in our other project. After additional research, I realized that without batching, this library can't be used to collect balances at the scale that I needed and at the time the current direction of the library was uncertain. I ended up implementing batching specifically for balance requests explicitly.
 
Now that things have stabilized and there's #3 which implements transparent batching, it's time to modernize `ethbalance` and start using it internally in place of the ad-hoc solution, that didn't use the library.

### How it works

Given an array `BalanceRequest` structs the library creates a tree-like structure of balances of the form:

```
balances[block][address][source] = value
```

There are two methods that compute the `balances` map with values being either `strings` representing the raw hex result or `*big.Int` after having them converted.

#### Retry mechanism 

The library also implements a retry mechanism that works by keeping a record of which `BalanceRequest`s failed on each cycle and retrying the RPC calls from them in the following cycle. The function stops after a finite amount of cycles or when there are no more requests unfinished.

The failure isn't actually all or nothing. When the retry mechanism gives up the function actually returns the balances that it managed to resolve until that point, alongside the error. Unsure if this is a wrong approach but most use-cases will ignore the result when there's an error anyway.

#### Error handling

The function returns a single error that contains references to all the requests that failed. and their respective errors. The string format of that error prints all unique exceptions and the requests grouped under them to make it easier to read, but users of the library can introspect the error and get insight into what requests failed and why.

Because of this, it's actually useful that partial results are returned in some situations.