### PR TITLE
Fix an issue with Int balances not returning partial result

### DIFF
--- a/ethbalance/errors.go
+++ b/ethbalance/errors.go
@@ -23,17 +23,6 @@ func (cbe CollectBalancesError) Error() string {
 	return fmt.Sprintf("Unable to collect balances because of these errors:\n%s", fullErrorMessage)
 }
 
-// DecodeBalancesError wraps errors returned when trying to decode the responses
-type DecodeBalancesError struct {
-	Errors []*RequestError
-}
-
-// Error message aggregates all unique errors
-func (dbe DecodeBalancesError) Error() string {
-	fullErrorMessage := renderFullErrorMessage(dbe.Errors)
-	return fmt.Sprintf("Unable to collect balances because of these errors:\n%s", fullErrorMessage)
-}
-
 func renderFullErrorMessage(errors []*RequestError) string {
 	var fullErrorMessage string
 	errorMessages := make(map[string]string)


### PR DESCRIPTION
Sadly it looks like the behavior on the `GetRawBalanceResults` didn't translate correctly to the `GetIntBalanceResults`. And partial results weren't decoded and returned. Also when realizing this it looks like it doesn't make sense to separate `DecodeBalanceErrors` from `CollectBalanceErrors` as there should just be one that encompasses all.